### PR TITLE
Default loss function and conda environment

### DIFF
--- a/experiments/args.py
+++ b/experiments/args.py
@@ -77,7 +77,7 @@ def parse_args_main():
     parser.add_argument("--logit_scale_init", type=float,
                         help="Value used to initialize the learned logit_scale. \
                               CLIP used np.log(1 / 0.07) = 2.65926.")
-    parser.add_argument("--loss_fn", type=str,
+    parser.add_argument("--loss_fn", type=str, default="symile",
                         choices = ["symile", "clip"],
                         help="Loss function to use for training.")
     parser.add_argument("--lr", type=float,

--- a/experiments/env/environment.yml
+++ b/experiments/env/environment.yml
@@ -196,4 +196,3 @@ dependencies:
       - cffi==1.17.1
       - pycparser==2.22
       - soundfile==0.12.1
-prefix: /gpfs/scratch/as16583/envs/symile-env

--- a/experiments/env/environment.yml
+++ b/experiments/env/environment.yml
@@ -196,5 +196,4 @@ dependencies:
       - cffi==1.17.1
       - pycparser==2.22
       - soundfile==0.12.1
-      - symile-experiments==0.1.0
 prefix: /gpfs/scratch/as16583/envs/symile-env


### PR DESCRIPTION
Adding a default value to the loss_fn argument. The readme says the default value is symile but that value isn't being set in the args file.

Removing the symile-experiments package from the env.yml file. The pip install stage of creating the symile-env conda environment fails because it can't find symile-experiments==0.1.0. The next step in the readme installs that.